### PR TITLE
UI.Grid.Исправление borderRadius item-элемента для отображения в сторибуке

### DIFF
--- a/packages/ui/src/Grid/Grid.stories.tsx
+++ b/packages/ui/src/Grid/Grid.stories.tsx
@@ -16,7 +16,7 @@ const Item = (props: BoxProps) => (
     sx={{
       border: '1px solid',
       borderColor: (theme) => theme.palette.grey[300],
-      borderRadius: 3,
+      borderRadius: '3px',
       textAlign: 'center',
       p: 1,
     }}


### PR DESCRIPTION
там из theme не правильно тянется spacing, идет 4px, вместо 3, поэтому для компонента хелпера только для стори бук было решено оставить просто "3px", забыл дописать 'px', и вместо 3px там сейчас 12px