### PR TITLE
build: Добавляет экспорт для @astral/ui/server

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,5 +45,15 @@
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
     "copyfiles": "^2.4.1"
+  },
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
+    "./server": {
+      "import": "./esm/server/index.js",
+      "require": "./cjs/server/index.js"
+    }
   }
 }


### PR DESCRIPTION
Добавлено поле `exports` в `package.json` пакета `@astral/ui`, что позволяет делать такие импорты:
```
import {
  StylesCache,
} from '@astral/ui/server'
```