### PR TITLE
UIKIT-303: bug(ui,Notification): Использование injectStyle только в браузере

### DIFF
--- a/packages/ui/src/Notification/NotificationContainer/NotificationContainer.tsx
+++ b/packages/ui/src/Notification/NotificationContainer/NotificationContainer.tsx
@@ -6,7 +6,9 @@ import { NOTIFY_POSITIONS } from '../constants';
 
 import { ToastContainerStyled } from './styled';
 
-injectStyle();
+if (typeof window !== 'undefined') {
+  injectStyle();
+}
 
 export interface NotificationContainerProps extends ToastContainerProps {}
 


### PR DESCRIPTION
Тесты jsdom падают с document is not defined в React компонентах из-за injectStyle в NoficationContainer, было реализована работа injectStyle только в браузере