### PR TITLE
UIKIT-306: bug(ui,DataGrid): Исправлена работа таблицы без сортировки

### DIFF
--- a/packages/ui/src/DataGrid/DataGrid.tsx
+++ b/packages/ui/src/DataGrid/DataGrid.tsx
@@ -9,7 +9,7 @@ import { DataGridContainer, StyledTableContainer } from './styled';
 import { DataGridColumns, DataGridRow, DataGridSort } from './types';
 
 export type DataGridProps<
-  Data = DataGridRow,
+  Data extends object = DataGridRow,
   SortField extends keyof Data = keyof Data,
 > = {
   /**
@@ -52,7 +52,7 @@ export type DataGridProps<
    * @example <DataGrid onSort={({fieldId: 'test', sort: 'asc'}) => console.log('sorted')} />
    * Обработчик сортировки
    */
-  onSort: (sorting: DataGridSort<SortField>[]) => void;
+  onSort?: (sorting: DataGridSort<SortField>[]) => void;
   /**
    * @example <DataGrid  Footer={<DataGridPagination />} />
    * Компонент кастомного футера (н-р Pagination)
@@ -82,7 +82,10 @@ export type DataGridProps<
   minDisplayRows?: number;
 };
 
-export function DataGrid<Data extends object, SortField extends keyof Data>({
+export function DataGrid<
+  Data extends object = DataGridRow,
+  SortField extends keyof Data = keyof Data,
+>({
   columns,
   rows = [],
   selectedRows = [],

--- a/packages/ui/src/DataGrid/DataGridHead/DataGridHead.tsx
+++ b/packages/ui/src/DataGrid/DataGridHead/DataGridHead.tsx
@@ -15,7 +15,7 @@ export type DataGridHeadProps<
   selectable: boolean;
   onSelectAllRows: (event: ChangeEvent<HTMLInputElement>) => void;
   sorting: DataGridSort<SortField>[];
-  onSort: (sorting: DataGridSort<SortField>[]) => void;
+  onSort?: (sorting: DataGridSort<SortField>[]) => void;
   uncheckedRowsCount: number;
   rowsCount: number;
 };
@@ -40,28 +40,30 @@ export function DataGridHead<Data, SortField extends keyof Data>({
   );
 
   const handleSort = useCallback(
-    (field: SortField, sortable?: boolean) => {
-      if (sortable) {
-        const currentSort = sorting.find(({ fieldId }) => fieldId === field);
-
-        // если для выбранного столбца текущая сортировка ASC - меняем на DESC
-        if (currentSort && currentSort.sort === SortStates.ASC) {
-          const newSorting = [
-            ...sorting.filter(({ fieldId }) => fieldId !== field),
-            { fieldId: field, sort: SortStates.DESC },
-          ];
-
-          return onSort(newSorting);
-          // если для выбранного столбца текущая сортировка DESC - убираем сортировку
-        } else if (currentSort && currentSort.sort === SortStates.DESC) {
-          const newSorting = sorting.filter(({ fieldId }) => fieldId !== field);
-
-          return onSort(newSorting);
-        }
-
-        // если для выбранного столбца нет сортировки - добавляем сортировку ASC
-        onSort([...sorting, { fieldId: field, sort: SortStates.ASC }]);
+    (field: SortField) => {
+      if (!onSort) {
+        return;
       }
+
+      const currentSort = sorting.find(({ fieldId }) => fieldId === field);
+
+      // если для выбранного столбца текущая сортировка ASC - меняем на DESC
+      if (currentSort && currentSort.sort === SortStates.ASC) {
+        const newSorting = [
+          ...sorting.filter(({ fieldId }) => fieldId !== field),
+          { fieldId: field, sort: SortStates.DESC },
+        ];
+
+        return onSort(newSorting);
+        // если для выбранного столбца текущая сортировка DESC - убираем сортировку
+      } else if (currentSort && currentSort.sort === SortStates.DESC) {
+        const newSorting = sorting.filter(({ fieldId }) => fieldId !== field);
+
+        return onSort(newSorting);
+      }
+
+      // если для выбранного столбца нет сортировки - добавляем сортировку ASC
+      onSort([...sorting, { fieldId: field, sort: SortStates.ASC }]);
     },
     [sorting, onSort],
   );

--- a/packages/ui/src/DataGrid/DataGridHeadColumn/DataGridHeadColumn.tsx
+++ b/packages/ui/src/DataGrid/DataGridHeadColumn/DataGridHeadColumn.tsx
@@ -11,7 +11,7 @@ export type DataGridHeadColumnProps<
   Data = DataGridRow,
   SortField extends keyof Data = keyof Data,
 > = {
-  onSort: (field: SortField, sortable?: boolean) => void;
+  onSort: (field: SortField) => void;
   sorting: DataGridSort<SortField>[];
   label?: string;
   sortable?: boolean;
@@ -40,13 +40,18 @@ export function DataGridHeadColumn<Data, SortField extends keyof Data>({
   );
 
   const handleSortClick = () => {
-    if (field) {
-      onSort(field as SortField, sortable);
+    if (field && sortable) {
+      onSort(field as SortField);
     }
   };
 
   return (
-    <StyledTableCell onClick={handleSortClick} align={align} width={width}>
+    <StyledTableCell
+      onClick={handleSortClick}
+      align={align}
+      width={width}
+      sortable={sortable}
+    >
       <Typography variant="pointer">{label}</Typography>
       {sortable && (
         <StyledTableSortLabel

--- a/packages/ui/src/DataGrid/DataGridHeadColumn/styled.tsx
+++ b/packages/ui/src/DataGrid/DataGridHeadColumn/styled.tsx
@@ -6,6 +6,7 @@ import { TableCell, TableSortLabel } from '../../Table';
 
 type StyledTableCellProps = TableCellProps & {
   width?: CSSProperties['width'];
+  sortable?: boolean;
 };
 
 export const StyledTableSortLabel = styled(TableSortLabel)<TableSortLabelProps>`
@@ -17,7 +18,8 @@ export const StyledTableCell = styled(TableCell, {
 })<StyledTableCellProps>`
   width: ${({ width = 'auto' }) => width};
 
-  cursor: pointer;
-
+  cursor: ${({ sortable }) => (sortable ? 'pointer' : 'initial')};
+  padding: ${({ theme }) => theme.spacing(3, 4)};
+  color: ${({ theme }) => theme.palette.grey[700]};
   user-select: none;
 `;


### PR DESCRIPTION
https://astraltrack.atlassian.net/browse/UIKIT-306
1. onSort теперь не обязательный параметр для DataGrid
2. при sortable: false - курсор дефолтный (ранее всегда был pointer, не важно была ли сортировка или нет)
3. Второй generic SortField теперь не обязательный (ранее нужно или не указывать generic или указать два, даже если нет сортировки в таблице)
4. Исправлена верстка хедера таблицы ближе к дизайну: Увеличен отступ сверху и снизу (а то слишком маленькая строка хедеров) и добавлен серый цвет для заголовков таблицы