### PR TITLE
bug(UIKIT-327,ui,OverflowTypography): Возврат префикса для OverflowTypography

### DIFF
--- a/packages/ui/src/OverflowTypography/styles.ts
+++ b/packages/ui/src/OverflowTypography/styles.ts
@@ -6,7 +6,8 @@ import { OverflowedProps } from './OverflowTypography';
 export const OverflowTypographyWrapper = styled(Typography, {
   shouldForwardProp: (name) => name !== 'rowsCount',
 })<Required<OverflowedProps>>`
-  display: box;
+  /* stylelint-disable-next-line */
+  display: -webkit-box;
   max-width: 100%;
   overflow: hidden;
 


### PR DESCRIPTION
стайлинт выпилил префикс, без которого логика компонента не работает
хотфикс для внезапно пропафшего префикса