### PR TITLE
feat(UIKIT-380): добавление цветовой темы KEDO

### DIFF
--- a/.storybook/themes.js
+++ b/.storybook/themes.js
@@ -37,6 +37,10 @@ export const themes = [
     theme: createTheme({ brand: Brand.EDO, fontsUrls })
   },
   {
+    name: 'Astral.kedo',
+    theme: createTheme({ brand: Brand.KEDO, fontsUrls })
+  },
+  {
     name: 'Astral.lkp',
     theme: createTheme({ brand: Brand.LKP, fontsUrls })
   },

--- a/packages/ui/src/theme/constants.ts
+++ b/packages/ui/src/theme/constants.ts
@@ -1,6 +1,7 @@
 export enum Brand {
   DEFAULT = 'DEFAULT',
   EDO = 'EDO',
+  KEDO = 'KEDO',
   AO5 = 'AO5',
   OFD = 'OFD',
   SIGN = 'SIGN',

--- a/packages/ui/src/theme/palette/brandPalette.ts
+++ b/packages/ui/src/theme/palette/brandPalette.ts
@@ -95,6 +95,7 @@ export const brandPalette: Record<Brand, BrandColors> = {
   [Brand.DEFAULT]: defaultBrandPalette,
   [Brand.AO5]: ao5Palette,
   [Brand.EDO]: edoPalette,
+  [Brand.KEDO]: edoPalette,
   [Brand.OFD]: ofdPalette,
   [Brand.SIGN]: signPalette,
   [Brand.LKP]: lkpPalette,

--- a/packages/ui/src/theme/palette/brandPalette.ts
+++ b/packages/ui/src/theme/palette/brandPalette.ts
@@ -39,6 +39,19 @@ const edoPalette: BrandColors = {
   100: '#EFEBFF',
 };
 
+const kedoPalette: BrandColors = {
+  secondary: '#5653FF',
+  900: '#5D3FD4',
+  800: '#6746EB',
+  700: '#8566FF',
+  600: '#9075FF',
+  500: '#9D85FF',
+  400: '#B29EFF',
+  300: '#C2B2FF',
+  200: '#E0D9FF',
+  100: '#EFEBFF',
+};
+
 const ao5Palette: BrandColors = {
   secondary: '#14A5D3',
   900: '#0068B2',
@@ -95,7 +108,7 @@ export const brandPalette: Record<Brand, BrandColors> = {
   [Brand.DEFAULT]: defaultBrandPalette,
   [Brand.AO5]: ao5Palette,
   [Brand.EDO]: edoPalette,
-  [Brand.KEDO]: edoPalette,
+  [Brand.KEDO]: kedoPalette,
   [Brand.OFD]: ofdPalette,
   [Brand.SIGN]: signPalette,
   [Brand.LKP]: lkpPalette,


### PR DESCRIPTION
Цвета КЭДО повторяют цвето ЭДО, но мало ли когда дизайнерам/PO захочется изменить что то в цветах, чтобы не аффектило цвета ЭДО надо бы создать и использовать для этого отдельную сущность в цветовой палитре