### PR TITLE
bug(UIKIT-410,ui,palette): Добавлен secondary цвет для текста

### DIFF
--- a/packages/ui/src/theme/palette/palette.ts
+++ b/packages/ui/src/theme/palette/palette.ts
@@ -111,7 +111,7 @@ export const getPalette = (brand: Brand = Brand.DEFAULT): PaletteOptions => {
     },
     text: {
       primary: '#072D57',
-      secondary: '#072D57',
+      secondary: '#557192',
       disabled: '#99A9BA',
     },
     grey: {


### PR DESCRIPTION
Добавил secondary цвет для текста, обычно дизайнеры используют вот этот цвет для подсказок, но это обсуждаемо и можно пообщаться с дизайнерами еще - но пока все дизайнеры в отпуске лучше такой серый, чем черный как сейчас