### PR TITLE
bug(UIKIT-447,ui,BackdropManager): фолбэк для nodejs окружения

### DIFF
--- a/packages/ui/src/BackdropStack/services/BackdropStackManager/BackdropStackManager.ts
+++ b/packages/ui/src/BackdropStack/services/BackdropStackManager/BackdropStackManager.ts
@@ -23,7 +23,7 @@ class BackdropStackManager {
   private currentPointerId: PointerId = null;
 
   constructor() {
-    document?.addEventListener(
+    globalThis?.document?.addEventListener(
       'pointerdown',
       () => (this.currentPointerId = this.generateID()),
     );
@@ -40,8 +40,8 @@ class BackdropStackManager {
   };
 
   public generateID = () => {
-    return String(Math.random())
-  }
+    return String(Math.random());
+  };
 
   public remove = (id: PopId) => {
     this.stack = this.stack.filter((item) => item !== id);


### PR DESCRIPTION
сейчас крашится на тестах, потому что в окружении ноды нету `document` в глобальной области.

но зато `globalThis` есть и в `nodejs` и в браузере, и в браузере globalThis ссылается на `window` который уже содержит `document`
![image](https://user-images.githubusercontent.com/59384103/192946016-78b65a01-2e38-4aaa-8197-10c0598c858f.png)
![image](https://user-images.githubusercontent.com/59384103/192946146-2ba907b0-3823-411d-91f0-4744d5eec266.png)
