### PR TITLE
feat(UIKIT-470): реализация абстрактного хука useForwardedRef

### DIFF
--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export * from './useLocalStorage';
 
 export * from './useMenu';
+
+export * from './useForwardedRef';

--- a/packages/ui/src/hooks/useForwardedRef/index.ts
+++ b/packages/ui/src/hooks/useForwardedRef/index.ts
@@ -1,0 +1,1 @@
+export * from './useForwardedRef';

--- a/packages/ui/src/hooks/useForwardedRef/useForwardedRef.ts
+++ b/packages/ui/src/hooks/useForwardedRef/useForwardedRef.ts
@@ -1,0 +1,12 @@
+import { ForwardedRef, useImperativeHandle, useRef } from 'react';
+
+/**
+ * @description хук позволяет использовать опциональный реф пришедший сверху, т.к. ForwardedRef может являться колбэком, это может подходить не для всех компонентов, яркий пример MaskField
+ */
+export const useForwardedRef = <T>(forwardedRef: ForwardedRef<T>) => {
+  const localRef = useRef<T>(null);
+
+  useImperativeHandle(forwardedRef, () => localRef.current!, [forwardedRef]);
+
+  return localRef;
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -155,3 +155,5 @@ export * from './LocalizationProvider';
 export * from './ContentState';
 
 export * from './Chevron';
+
+export * from './hooks/useForwardedRef';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -155,5 +155,3 @@ export * from './LocalizationProvider';
 export * from './ContentState';
 
 export * from './Chevron';
-
-export * from './hooks/useForwardedRef';


### PR DESCRIPTION
Дизайн ревью не требуется, чисто технический компонент.

**Что**:
Данный хук является адаптером использования опционального рефа пришедшего сверху, т.к. ForwardedRef может являться колбэком. Это решит проблему совместимости react-hook-form , и forwardedRef в MaskField

**Зачем**:
Текущая реализация MaskField не имеет обертки forwardRef и поэтому кидает варнинг о том что мы забыли сделать это, но если мы оборачиваем реализацию MaskField в forwardRef, то тогда ref из react-hook-form не подходит под нужный нам формат.



**Почему**:
Изначально этот хук был создан в ветке нового ДатаПикера, и я предполагал что в рамках пул реквеста на ДатаПикер этот хук попадет в репозиторий, но с появлением форм, оказалось что им тоже требуется использовать его, для совместимости с последними изменениями по ДатаПикеру. А так как формы зависят от кита, как от отдельного плагина, то потребовалось создать отдельный пул реквест на создание этого абстрактного хука, чтобы он попал в релиз первее чем ДатаПикер