### PR TITLE
bug(UIKIT-419,ui,DatePicker): возврат кастомного форматирования/парсинга даты

### DIFF
--- a/packages/ui/src/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/DatePicker/DatePicker.tsx
@@ -76,7 +76,7 @@ const DatePickerInner = forwardRef<
       (value: string) => {
         setMaskedDate(value);
 
-        const date = parseDate(value);
+        const date = parseDate(value, mask);
 
         if (value === '' || !isDate(date)) {
           setSelectedDate(null);
@@ -88,6 +88,7 @@ const DatePickerInner = forwardRef<
     );
 
     const handleDayPick = (date: Date) => {
+      console.log(date, formatDate(date, mask));
       setMaskedDate(formatDate(date, mask));
       setSelectedDate(date);
       closePopper();

--- a/packages/ui/src/utils/date/format/formatDate/formatDate.ts
+++ b/packages/ui/src/utils/date/format/formatDate/formatDate.ts
@@ -1,9 +1,28 @@
-import dayjs from 'dayjs';
+import { zeroPad } from '../../../zeroPad';
+import { DateMask, DateMaskElements } from '../maskDate';
 
-import { DateMask } from '../maskDate';
+type ElementsMap = Record<DateMaskElements, (date: Date) => number>;
+
+const elementsMap: ElementsMap = {
+  [DateMaskElements.day]: (date) => date.getUTCDate(),
+  [DateMaskElements.month]: (date) => date.getUTCMonth() + 1,
+  [DateMaskElements.year]: (date) => date.getUTCFullYear(),
+  [DateMaskElements.hour]: (date) => date.getUTCHours(),
+  [DateMaskElements.minute]: (date) => date.getUTCMinutes(),
+  [DateMaskElements.second]: (date) => date.getUTCSeconds(),
+};
 
 /**
  * @description утилита для генерации строковой даты по заданной маске
  */
-export const formatDate = (date: Date, mask: DateMask): string =>
-  dayjs(date).format(mask);
+export const formatDate = (
+  date: Date,
+  mask: DateMask,
+  separator = '.',
+): string =>
+  mask
+    .split(separator)
+    .map((element) => elementsMap[element]?.(date))
+    .filter(Boolean)
+    .map((value) => zeroPad(value, 2))
+    .join(separator);

--- a/packages/ui/src/utils/date/format/maskDate.ts
+++ b/packages/ui/src/utils/date/format/maskDate.ts
@@ -3,3 +3,12 @@
  * @example DD.MM.YYYY.hh.mm.ss
  */
 export type DateMask = string;
+
+export enum DateMaskElements {
+  day = 'DD',
+  month = 'MM',
+  year = 'YYYY',
+  hour = 'hh',
+  minute = 'mm',
+  second = 'ss',
+}

--- a/packages/ui/src/utils/date/format/parseDate/parseDate.ts
+++ b/packages/ui/src/utils/date/format/parseDate/parseDate.ts
@@ -1,6 +1,27 @@
-import dayjs from 'dayjs';
+import { DateMask, DateMaskElements } from '../maskDate';
+import { BuildIsoDateStringOptions, buildIsoDate } from '../../buildIsoDate';
+
+type ElementsMap = Record<DateMaskElements, keyof BuildIsoDateStringOptions>;
+
+const orderMap: ElementsMap = {
+  [DateMaskElements.year]: 'year',
+  [DateMaskElements.month]: 'month',
+  [DateMaskElements.day]: 'day',
+  [DateMaskElements.hour]: 'hour',
+  [DateMaskElements.minute]: 'minute',
+  [DateMaskElements.second]: 'second',
+};
 
 /**
  * @description утилита конвертации строковой даты созданной по маске обратно в Date
  */
-export const parseDate = (date: string): Date => dayjs(date).toDate();
+export const parseDate = (date: string, mask: DateMask): Date => {
+  const dateArr = date.split('.');
+  const options: BuildIsoDateStringOptions = { year: 1900 };
+
+  mask.split('.').forEach((element, index) => {
+    options[orderMap[element as DateMaskElements]] = parseInt(dateArr[index]);
+  });
+
+  return buildIsoDate(options);
+};


### PR DESCRIPTION
выяснилось что парсер/форматтер от `dayjs` не умеет работать с данными как нам нужно по бизнес логике, так же в нем присутствует проблема генерации даты по локальному времени пользователя, что приводит к проблемам при выборе даты.

решение от `date-format` не типизировано, и так же работает как то странно.

парсер/форматтер от `date-fns` весит слишком много (20кб в гзипе, P.S. реакт весит 2кб)