### PR TITLE
bug(UIKIT-477,ui,Datepicker): Фикс для рендера месяца после зимнего времени

### DIFF
--- a/packages/ui/src/DatePicker/MonthPicker/hooks/useMonthsGrid/useMonthsGrid.ts
+++ b/packages/ui/src/DatePicker/MonthPicker/hooks/useMonthsGrid/useMonthsGrid.ts
@@ -38,7 +38,7 @@ export const useMonthsGrid: GridBuilder<MonthItem> = ({
       const date = buildIsoDate({ year, month: i + 1 });
 
       grid.push({
-        date: addMonths(startDate, i),
+        date,
         selected: selectedMonth === i && selectedYear === year,
         month: i + 1,
         isCurrent: i === currentMonth && year === currentYear,


### PR DESCRIPTION
Если в пикере выбрать 2004й год(или любой где есть зимнее время года), потом выбрать апрель, то по факту будет отрендерен календарь для марта.

Проблема заключается в том что в марте часовой пояс на 1 больше, чем в последующем месяце. Следовательно при добавлении одного месяца нехватает одного часа, и календарь начинает строиться для предыдущего месяца.

Сложно локализуемая проблема, но при этом фикс в 1 строку.