### PR TITLE
bug(UIKIT-500,ui,Autocomplete): Обнуление лишнего паддинга в Autocomplete

### DIFF
--- a/packages/ui/src/theme/components/MuiAutocomplete.ts
+++ b/packages/ui/src/theme/components/MuiAutocomplete.ts
@@ -5,11 +5,6 @@ import { AutocompleteSizes } from '../../Autocomplete/constants';
 
 export const MuiAutocomplete: Components<Theme>['MuiAutocomplete'] = {
   styleOverrides: {
-    root({ theme }) {
-      return {
-        padding: theme.spacing(1),
-      };
-    },
     inputRoot({ theme, ownerState: { size } }) {
       return {
         paddingTop: `${theme.spacing(1)} !important`,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59384103/199155089-b31d29a4-208c-4e8f-96b0-072d3f1ca33e.png)

не стал делать через `styled` потому что там начинаются проблемы с типами.