### PR TITLE
bug(UIKIT-556,ui,PageHeader): добавлена высота строки для заголовка страницы

### DIFF
--- a/packages/ui/src/PageHeader/styles.ts
+++ b/packages/ui/src/PageHeader/styles.ts
@@ -39,5 +39,5 @@ export const PageHeaderTitle = styled(Typography)`
   grid-area: title;
   align-items: center;
 
-  line-height: 32px;
+  line-height: ${({ theme }) => theme.typography.pxToRem(32)};
 `;

--- a/packages/ui/src/PageHeader/styles.ts
+++ b/packages/ui/src/PageHeader/styles.ts
@@ -38,4 +38,6 @@ export const PageHeaderTitle = styled(Typography)`
   display: flex;
   grid-area: title;
   align-items: center;
+
+  line-height: 32px;
 `;


### PR DESCRIPTION
Высота заголовка отличалась для страниц с кнопками и без (у кнопок она 32px)