### PR TITLE
bug(UIKIT-585,ui,DatePicker): фикс неправильной проверки на выбранный день

### DIFF
--- a/packages/ui/src/DatePicker/DatePicker.test.tsx
+++ b/packages/ui/src/DatePicker/DatePicker.test.tsx
@@ -78,6 +78,15 @@ describe('DatePicker', () => {
     expect(btn).not.toBeDisabled();
   });
 
+  it('Props:maxDate: в пикере выбранной отображается правильная выбранная дата при использовании даты со смещением', async () => {
+    renderWithTheme(<DatePicker value={new Date('2022-12-16T18:59:00Z')} />);
+    fireEvent.focus(screen.getByRole('textbox'));
+
+    const selected = screen.getAllByText('16')[0].getAttribute('aria-selected');
+
+    expect(selected).toBeTruthy();
+  });
+
   it('Props:value: при изменении меняется выбранная дата в календаре', async () => {
     const callbacks: { setValue: (date?: Date) => void } = {
       setValue: () => undefined,

--- a/packages/ui/src/DatePicker/DayPicker/hooks/useDaysGrid/useDaysGrid.ts
+++ b/packages/ui/src/DatePicker/DayPicker/hooks/useDaysGrid/useDaysGrid.ts
@@ -132,8 +132,9 @@ export const useDaysGrid: GridBuilder<DayItem, BuildMonthGridOptions> = ({
         isOutOfAvailableRange: dateMonth !== month,
         selected:
           !!selectedDate &&
-          Number(date) >= Number(selectedDate) &&
-          Number(date) < Number(addDays(selectedDate, 1)),
+          selectedDate.getUTCFullYear() === date.getUTCFullYear() &&
+          selectedDate.getUTCMonth() === date.getUTCMonth() &&
+          selectedDate.getUTCDate() === date.getUTCDate(),
         isCurrent:
           date.getUTCFullYear() === currentDate.getFullYear() &&
           date.getUTCDate() === currentDate.getDate() &&

--- a/packages/ui/src/DatePicker/DayPicker/hooks/useDaysGrid/useDaysGrid.ts
+++ b/packages/ui/src/DatePicker/DayPicker/hooks/useDaysGrid/useDaysGrid.ts
@@ -10,6 +10,7 @@ import {
 import { GridBuilder, GridItem } from '../../../types';
 import { buildGridResult } from '../../../utils/buildGridItem';
 import { MinMaxDateContext } from '../../../MinMaxDateContext';
+import { compareDateDayByUTC } from '../../../utils/compareDateDayByUTC';
 
 export type DayItem = {
   /**
@@ -130,11 +131,7 @@ export const useDaysGrid: GridBuilder<DayItem, BuildMonthGridOptions> = ({
 
       grid.push({
         isOutOfAvailableRange: dateMonth !== month,
-        selected:
-          !!selectedDate &&
-          selectedDate.getUTCFullYear() === date.getUTCFullYear() &&
-          selectedDate.getUTCMonth() === date.getUTCMonth() &&
-          selectedDate.getUTCDate() === date.getUTCDate(),
+        selected: !!selectedDate && compareDateDayByUTC(selectedDate, date),
         isCurrent:
           date.getUTCFullYear() === currentDate.getFullYear() &&
           date.getUTCDate() === currentDate.getDate() &&

--- a/packages/ui/src/DatePicker/DayPicker/hooks/useDaysGrid/useDaysGrid.ts
+++ b/packages/ui/src/DatePicker/DayPicker/hooks/useDaysGrid/useDaysGrid.ts
@@ -5,6 +5,7 @@ import {
   DateCompareDeep,
   addDays,
   buildIsoDate,
+  isDate,
   isDateOutOfRange,
 } from '../../../../utils/date';
 import { GridBuilder, GridItem } from '../../../types';
@@ -131,7 +132,8 @@ export const useDaysGrid: GridBuilder<DayItem, BuildMonthGridOptions> = ({
 
       grid.push({
         isOutOfAvailableRange: dateMonth !== month,
-        selected: !!selectedDate && compareDateDayByUTC(selectedDate, date),
+        selected:
+          isDate(selectedDate) && compareDateDayByUTC(selectedDate, date),
         isCurrent:
           date.getUTCFullYear() === currentDate.getFullYear() &&
           date.getUTCDate() === currentDate.getDate() &&

--- a/packages/ui/src/DatePicker/utils/compareDateDayByUTC/compareDateDayByUTC.ts
+++ b/packages/ui/src/DatePicker/utils/compareDateDayByUTC/compareDateDayByUTC.ts
@@ -1,0 +1,8 @@
+/**
+ * @description утилита для сравнения двух дат на совпадение дня,
+ * пример применения DayPicker, для сравнения выбранной даты и каждой даты в пикере
+ */
+export const compareDateDayByUTC = (dateA: Date, dateB: Date) =>
+  dateA.getUTCFullYear() === dateB.getUTCFullYear() &&
+  dateA.getUTCMonth() === dateB.getUTCMonth() &&
+  dateA.getUTCDate() === dateB.getUTCDate();

--- a/packages/ui/src/DatePicker/utils/compareDateDayByUTC/index.ts
+++ b/packages/ui/src/DatePicker/utils/compareDateDayByUTC/index.ts
@@ -1,0 +1,1 @@
+export * from './compareDateDayByUTC';

--- a/packages/ui/src/utils/date/isDate/isDate.ts
+++ b/packages/ui/src/utils/date/isDate/isDate.ts
@@ -5,4 +5,5 @@ type Unknown = null | undefined | string | number | Date;
 /**
  * @description функция проверки значения на дату
  */
-export const isDate = (value: Unknown): value is Date => dayjs(value).isValid();
+export const isDate = (value: Unknown): value is Date =>
+  Boolean(value) && dayjs(value).isValid();


### PR DESCRIPTION
Если в качестве выбранной используется пограничное значение со смещением по часовому поясу, то выбранным считает следующий день.