### PR TITLE
bug(UIKIT-607,ui,OverflowTypography): округление для контент рект

### DIFF
--- a/packages/components/src/OverflowTypography/hooks/useOverflowed/useOverflowed.ts
+++ b/packages/components/src/OverflowTypography/hooks/useOverflowed/useOverflowed.ts
@@ -19,14 +19,13 @@ export const useOverflowed = (forwardedRef?: Ref<HTMLElement>) => {
 
   const handleResize = useCallback(
     debounce(([{ target, contentRect }]: ResizeObserverEntry[]) => {
-      /**
-       * @description сверка высоты дом ноды и высоты скролл контейнера, если скролл больше, то значит компонент переполнен контентом
-       */
-      const isScrollHeightBigger = contentRect.height < target.scrollHeight;
-      /**
-       * @description сверка ширины дом ноды и ширины скролл контейнера, если скролл больше, то значит компонент переполнен контентом
-       */
-      const isScrollWidthBigger = target.scrollWidth > contentRect.width;
+      // сверка высоты дом ноды и высоты скролл контейнера, если скролл больше, то значит компонент переполнен контентом
+      const isScrollHeightBigger =
+        Math.round(contentRect.height) < target.scrollHeight;
+
+      // сверка ширины дом ноды и ширины скролл контейнера, если скролл больше, то значит компонент переполнен контентом
+      const isScrollWidthBigger =
+        target.scrollWidth > Math.round(contentRect.width);
 
       setOverflow(isScrollHeightBigger || isScrollWidthBigger);
     }, 500),


### PR DESCRIPTION
`contentRect` возвращает размеры в вещественном виде (с десятыми долями пикселя), а метод дом ноды по получению размеров скрола возвращает округленное значение, отчего появлялись неожиданные срабатывания появления тултипа