### PR TITLE
feat(UIKIT-651,ui,Tag): Добавлены variant="text" и пропс size для тега

### DIFF
--- a/packages/components/src/CheckableTag/CheckableTag.stories.tsx
+++ b/packages/components/src/CheckableTag/CheckableTag.stories.tsx
@@ -47,6 +47,7 @@ export const ShowcaseColor: Story = () => {
       <CheckableTag
         label="Checkable tag"
         checked={checked}
+        variant="text"
         onChange={(event) => setChecked(event.target.checked)}
       />
 

--- a/packages/components/src/CheckableTag/styles.ts
+++ b/packages/components/src/CheckableTag/styles.ts
@@ -1,13 +1,17 @@
 import { styled } from '../styles';
 import { Tag, TagColor, TagVariant } from '../Tag';
 import { Theme } from '../theme';
+import { TagVariants } from '../Tag/enums';
 
 import { CheckableTagProps } from './CheckableTag';
 
 type StyledTagThemeProps = CheckableTagProps & { theme: Theme };
-type TagColorsKit = {
-  [variant in TagVariant]: { [color in TagColor]: string };
-};
+type TagColorsKit = Omit<
+  {
+    [variant in TagVariant]: { [color in TagColor]: string };
+  },
+  'text'
+>;
 
 const getHoverBgColor = ({
   theme,
@@ -22,6 +26,10 @@ const getHoverBgColor = ({
 
   if (checked) {
     return theme.palette.grey[700];
+  }
+
+  if (variant === TagVariants.TEXT) {
+    return theme.palette.grey[200];
   }
 
   const hoverBgColors: TagColorsKit = {
@@ -63,6 +71,10 @@ const getActiveBgColor = ({
 
   if (checked) {
     return theme.palette.grey[800];
+  }
+
+  if (variant === TagVariants.TEXT) {
+    return theme.palette.primary[100];
   }
 
   const activeBgColor: TagColorsKit = {

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -579,6 +579,10 @@ export const ShowcaseColor: Story = () => (
       />
       <Tag color="success" variant="contained" label="Тэг large" size="large" />
     </Stack>
+
+    <Stack direction="row" gap={2}>
+      <Tag color="error" variant="text" label="Тэг text" />
+    </Stack>
   </Stack>
 );
 

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -568,6 +568,17 @@ export const ShowcaseColor: Story = () => (
       <Tag avatar={svgAvatar} color="grey" label="Тэг" />
       <Tag avatar={svgAvatar} color="grey" label="Тэг" rounded />
     </Stack>
+
+    <Stack direction="row" gap={2}>
+      <Tag color="error" variant="contained" label="Тэг small" />
+      <Tag
+        color="warning"
+        variant="contained"
+        label="Тэг medium"
+        size="medium"
+      />
+      <Tag color="success" variant="contained" label="Тэг large" size="large" />
+    </Stack>
   </Stack>
 );
 

--- a/packages/components/src/Tag/Tag.tsx
+++ b/packages/components/src/Tag/Tag.tsx
@@ -5,24 +5,38 @@ import { ChipProps as MuiTagProps } from '@mui/material';
 import { WithoutEmotionSpecific } from '../types';
 
 import { StyledTag } from './styles';
-import { TagColor, TagVariant } from './types';
+import { TagColor, TagSize, TagVariant } from './types';
 
 export type TagProps = Omit<
   WithoutEmotionSpecific<MuiTagProps>,
   'color' | 'variant' | 'size'
 > & {
+  /**
+   * Цвет тега
+   */
   color?: TagColor;
+  /**
+   * Тип тега
+   */
   variant?: TagVariant;
+  /**
+   * Скругленная форма тега
+   */
   rounded?: boolean;
+  /**
+   * Размер тега
+   */
+  size?: TagSize;
 };
 
 export const Tag = forwardRef<HTMLDivElement, TagProps>(
-  ({ color, variant, deleteIcon, ...props }, ref) => {
+  ({ color, variant, deleteIcon, size = 'small', ...props }, ref) => {
     return (
       <StyledTag
         ref={ref}
         customColor={color}
         customVariant={variant}
+        customSize={size}
         {...props}
         deleteIcon={deleteIcon ? deleteIcon : <CrossSmOutlineSm />}
       />

--- a/packages/components/src/Tag/constants.ts
+++ b/packages/components/src/Tag/constants.ts
@@ -1,0 +1,7 @@
+import { TagSizes } from './enums';
+
+export const HEIGHTS = {
+  [TagSizes.SMALL]: '20px',
+  [TagSizes.MEDIUM]: '24px',
+  [TagSizes.LARGE]: '32px',
+};

--- a/packages/components/src/Tag/constants.ts
+++ b/packages/components/src/Tag/constants.ts
@@ -1,7 +1,0 @@
-import { TagSizes } from './enums';
-
-export const HEIGHTS = {
-  [TagSizes.SMALL]: '20px',
-  [TagSizes.MEDIUM]: '24px',
-  [TagSizes.LARGE]: '32px',
-};

--- a/packages/components/src/Tag/enums.ts
+++ b/packages/components/src/Tag/enums.ts
@@ -12,6 +12,12 @@ export enum TagVariants {
   LIGHT = 'light',
 }
 
+export enum TagSizes {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+}
+
 export enum TagStates {
   DEFAULT = 'default',
   HOVER = 'hover',

--- a/packages/components/src/Tag/enums.ts
+++ b/packages/components/src/Tag/enums.ts
@@ -13,12 +13,6 @@ export enum TagVariants {
   TEXT = 'text',
 }
 
-export enum TagSizes {
-  SMALL = 'small',
-  MEDIUM = 'medium',
-  LARGE = 'large',
-}
-
 export enum TagStates {
   DEFAULT = 'default',
   HOVER = 'hover',

--- a/packages/components/src/Tag/enums.ts
+++ b/packages/components/src/Tag/enums.ts
@@ -10,6 +10,7 @@ export enum TagColors {
 export enum TagVariants {
   CONTAINED = 'contained',
   LIGHT = 'light',
+  TEXT = 'text',
 }
 
 export enum TagSizes {

--- a/packages/components/src/Tag/styles.ts
+++ b/packages/components/src/Tag/styles.ts
@@ -17,7 +17,7 @@ type StyledTagProps = Omit<TagProps, 'color' | 'size'> & {
 
 type StyledTagThemeProps = StyledTagProps & { theme: Theme };
 
-const HEIGHTS: { [size in TagSize]: string } = {
+const HEIGHTS: Record<TagSize, string> = {
   small: '20px',
   medium: '24px',
   large: '32px',

--- a/packages/components/src/Tag/styles.ts
+++ b/packages/components/src/Tag/styles.ts
@@ -140,9 +140,8 @@ const getTagLabelPadding = ({
     case 'small':
       return theme.spacing(0, 1);
     case 'medium':
-      return theme.spacing(1, 2);
     case 'large':
-      return theme.spacing(1.5, 2);
+      return theme.spacing(0, 2);
   }
 };
 

--- a/packages/components/src/Tag/styles.ts
+++ b/packages/components/src/Tag/styles.ts
@@ -42,6 +42,10 @@ const getBgColor = ({
   customVariant,
   onDelete,
 }: StyledTagThemeProps): string => {
+  if (customVariant === 'text') {
+    return 'transparent';
+  }
+
   if (onDelete) {
     return theme.palette.grey[100];
   }
@@ -86,7 +90,7 @@ const getColor = ({
   customVariant,
   onDelete,
 }: StyledTagThemeProps): string => {
-  if (onDelete) {
+  if (onDelete || customVariant === 'text') {
     return theme.palette.grey[900];
   }
 

--- a/packages/components/src/Tag/styles.ts
+++ b/packages/components/src/Tag/styles.ts
@@ -3,9 +3,8 @@ import { Chip } from '@mui/material';
 import { styled } from '../styles';
 import { Theme } from '../theme';
 
-import { TagColors, TagStates } from './enums';
+import { TagColors, TagSizes, TagStates } from './enums';
 import { TagColor, TagSize, TagState, TagVariant } from './types';
-import { HEIGHTS } from './constants';
 
 import { TagProps } from '.';
 
@@ -17,6 +16,12 @@ type StyledTagProps = Omit<TagProps, 'color' | 'size'> & {
 };
 
 type StyledTagThemeProps = StyledTagProps & { theme: Theme };
+
+const HEIGHTS = {
+  [TagSizes.SMALL]: '20px',
+  [TagSizes.MEDIUM]: '24px',
+  [TagSizes.LARGE]: '32px',
+};
 
 const getShape = ({ theme, rounded }: StyledTagThemeProps): string => {
   if (rounded) {

--- a/packages/components/src/Tag/styles.ts
+++ b/packages/components/src/Tag/styles.ts
@@ -4,14 +4,16 @@ import { styled } from '../styles';
 import { Theme } from '../theme';
 
 import { TagColors, TagStates } from './enums';
-import { TagColor, TagState, TagVariant } from './types';
+import { TagColor, TagSize, TagState, TagVariant } from './types';
+import { HEIGHTS } from './constants';
 
 import { TagProps } from '.';
 
-type StyledTagProps = Omit<TagProps, 'color'> & {
+type StyledTagProps = Omit<TagProps, 'color' | 'size'> & {
   customColor?: TagColor;
   customVariant?: TagVariant;
   rounded?: boolean;
+  customSize: TagSize;
 };
 
 type StyledTagThemeProps = StyledTagProps & { theme: Theme };
@@ -119,12 +121,20 @@ const getColor = ({
 const getTagLabelPadding = ({
   theme,
   rounded,
+  customSize,
 }: StyledTagThemeProps): string => {
   if (rounded) {
     return theme.spacing(0, 2);
   }
 
-  return theme.spacing(0, 1);
+  switch (customSize) {
+    case 'small':
+      return theme.spacing(0, 1);
+    case 'medium':
+      return theme.spacing(1, 2);
+    case 'large':
+      return theme.spacing(1.5, 2);
+  }
 };
 
 const getDeleteIconBgColor = ({
@@ -146,9 +156,12 @@ const getDeleteIconBgColor = ({
 
 export const StyledTag = styled(Chip, {
   shouldForwardProp: (prop) =>
-    prop !== 'customColor' && prop !== 'customVariant' && prop !== 'rounded',
+    prop !== 'customColor' &&
+    prop !== 'customVariant' &&
+    prop !== 'rounded' &&
+    prop !== 'customSize',
 })<StyledTagProps>`
-  height: 20px;
+  height: ${({ customSize }) => HEIGHTS[customSize]};
 
   font-size: 14px;
 

--- a/packages/components/src/Tag/styles.ts
+++ b/packages/components/src/Tag/styles.ts
@@ -3,7 +3,7 @@ import { Chip } from '@mui/material';
 import { styled } from '../styles';
 import { Theme } from '../theme';
 
-import { TagColors, TagSizes, TagStates } from './enums';
+import { TagColors, TagStates } from './enums';
 import { TagColor, TagSize, TagState, TagVariant } from './types';
 
 import { TagProps } from '.';
@@ -17,10 +17,10 @@ type StyledTagProps = Omit<TagProps, 'color' | 'size'> & {
 
 type StyledTagThemeProps = StyledTagProps & { theme: Theme };
 
-const HEIGHTS = {
-  [TagSizes.SMALL]: '20px',
-  [TagSizes.MEDIUM]: '24px',
-  [TagSizes.LARGE]: '32px',
+const HEIGHTS: { [size in TagSize]: string } = {
+  small: '20px',
+  medium: '24px',
+  large: '32px',
 };
 
 const getShape = ({ theme, rounded }: StyledTagThemeProps): string => {

--- a/packages/components/src/Tag/types.ts
+++ b/packages/components/src/Tag/types.ts
@@ -1,9 +1,9 @@
-import { TagColors, TagSizes, TagStates, TagVariants } from './enums';
+import { TagColors, TagStates, TagVariants } from './enums';
 
 export type TagColor = `${TagColors}`;
 
 export type TagVariant = `${TagVariants}`;
 
-export type TagSize = `${TagSizes}`;
+export type TagSize = 'small' | 'medium' | 'large';
 
 export type TagState = `${TagStates}`;

--- a/packages/components/src/Tag/types.ts
+++ b/packages/components/src/Tag/types.ts
@@ -1,7 +1,9 @@
-import { TagColors, TagStates, TagVariants } from './enums';
+import { TagColors, TagSizes, TagStates, TagVariants } from './enums';
 
 export type TagColor = `${TagColors}`;
 
 export type TagVariant = `${TagVariants}`;
+
+export type TagSize = `${TagSizes}`;
 
 export type TagState = `${TagStates}`;


### PR DESCRIPTION
Реализовано две задачи:
feat(UIKIT-651,ui,Tag): Добавлен тип text для тега
feat(UIKIT-439,ui,Tag): Добавлен пропс размера для тега

size по умолчанию сделан small для обратной совместимости, т.к. изначально теги были реализованы с этой высотой