### PR TITLE
bug(UIKIT-643,ui,DataGridPagination): Футер скрывается на единственной странице

### DIFF
--- a/packages/components/src/DataGrid/DataGrid.stories.tsx
+++ b/packages/components/src/DataGrid/DataGrid.stories.tsx
@@ -246,10 +246,9 @@ const Template: Story = (args) => {
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
-            totalCount={10}
             Footer={
               <DataGridPagination
-                totalCount={data.length}
+                totalCount={10}
                 onChange={handleChangePage}
                 page={page}
               />
@@ -277,7 +276,6 @@ const Template: Story = (args) => {
             selectedRows={selected}
             onSelectRow={handleSelect}
             onRowClick={handleRowClick}
-            totalCount={data.length}
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
@@ -311,7 +309,6 @@ const Template: Story = (args) => {
             selectedRows={selected}
             onSelectRow={handleSelect}
             onRowClick={handleRowClick}
-            totalCount={data.length}
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
@@ -351,7 +348,6 @@ const Template: Story = (args) => {
             selectedRows={selected}
             onSelectRow={handleSelect}
             onRowClick={handleRowClick}
-            totalCount={data.length}
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
@@ -420,7 +416,6 @@ export const Showcase: Story = (args) => {
       selectedRows={selected}
       onSelectRow={handleSelect}
       onRowClick={handleRowClick}
-      totalCount={data.length}
       minDisplayRows={10}
       loading={loading}
       onSort={handleSort}

--- a/packages/components/src/DataGrid/DataGrid.stories.tsx
+++ b/packages/components/src/DataGrid/DataGrid.stories.tsx
@@ -314,7 +314,7 @@ const Template: Story = (args) => {
             sorting={sorting}
             Footer={
               <DataGridPagination
-                totalCount={data.length}
+                totalCount={0}
                 onChange={handleChangePage}
                 page={page}
               />

--- a/packages/components/src/DataGrid/DataGrid.stories.tsx
+++ b/packages/components/src/DataGrid/DataGrid.stories.tsx
@@ -226,6 +226,7 @@ const Template: Story = (args) => {
       <ExampleTemplate.Case
         title="DataGrid без пагинации"
         descriptionList={[
+          'Пагинация скрыта, так как totalCount(10) меньше или равен minDisplayRows(10)',
           'Растягивается по всей доступной высоте котейнера (600px)',
         ]}
       >
@@ -245,6 +246,14 @@ const Template: Story = (args) => {
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
+            totalCount={10}
+            Footer={
+              <DataGridPagination
+                totalCount={data.length}
+                onChange={handleChangePage}
+                page={page}
+              />
+            }
           />
         </Stack>
       </ExampleTemplate.Case>
@@ -268,6 +277,7 @@ const Template: Story = (args) => {
             selectedRows={selected}
             onSelectRow={handleSelect}
             onRowClick={handleRowClick}
+            totalCount={data.length}
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
@@ -301,6 +311,7 @@ const Template: Story = (args) => {
             selectedRows={selected}
             onSelectRow={handleSelect}
             onRowClick={handleRowClick}
+            totalCount={data.length}
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
@@ -340,6 +351,7 @@ const Template: Story = (args) => {
             selectedRows={selected}
             onSelectRow={handleSelect}
             onRowClick={handleRowClick}
+            totalCount={data.length}
             loading={loading}
             onSort={handleSort}
             sorting={sorting}
@@ -408,6 +420,7 @@ export const Showcase: Story = (args) => {
       selectedRows={selected}
       onSelectRow={handleSelect}
       onRowClick={handleRowClick}
+      totalCount={data.length}
       minDisplayRows={10}
       loading={loading}
       onSort={handleSort}

--- a/packages/components/src/DataGrid/DataGrid.test.tsx
+++ b/packages/components/src/DataGrid/DataGrid.test.tsx
@@ -6,64 +6,6 @@ import { DataGrid } from './DataGrid';
 import { DataGridColumns, DataGridSort } from './types';
 
 describe('DataGrid', () => {
-  it('Props:totalCount=1:minDisplayRows=10: Footer не отображается, totalCount <= minDisplayRows', () => {
-    type DataItem = {
-      name: string;
-    };
-
-    const columns: DataGridColumns<DataItem>[] = [
-      {
-        field: 'name',
-        label: 'Наименование',
-        sortable: true,
-      },
-    ];
-
-    renderWithTheme(
-      <DataGrid
-        keyId="id"
-        rows={[{ name: 'name' }]}
-        columns={columns}
-        Footer={<span>Footer is visible</span>}
-        totalCount={1}
-        minDisplayRows={10}
-      />,
-    );
-
-    const title = screen.queryByText(/Footer is visible/i);
-
-    expect(title).not.toBeInTheDocument();
-  });
-
-  it('Props:totalCount=10:minDisplayRows=1: Footer отображается, totalCount > minDisplayRows', () => {
-    type DataItem = {
-      name: string;
-    };
-
-    const columns: DataGridColumns<DataItem>[] = [
-      {
-        field: 'name',
-        label: 'Наименование',
-        sortable: true,
-      },
-    ];
-
-    renderWithTheme(
-      <DataGrid
-        keyId="id"
-        rows={[{ name: 'name' }]}
-        columns={columns}
-        minDisplayRows={1}
-        totalCount={10}
-        Footer={<span>Footer is visible</span>}
-      />,
-    );
-
-    const title = screen.getByText('Footer is visible');
-
-    expect(title).toBeInTheDocument();
-  });
-
   it('Props:columns: отображаются названия колонок', () => {
     const columns = [
       {

--- a/packages/components/src/DataGrid/DataGrid.test.tsx
+++ b/packages/components/src/DataGrid/DataGrid.test.tsx
@@ -6,6 +6,64 @@ import { DataGrid } from './DataGrid';
 import { DataGridColumns, DataGridSort } from './types';
 
 describe('DataGrid', () => {
+  it('Props:totalCount=1:minDisplayRows=10: Footer не отображается, totalCount <= minDisplayRows', () => {
+    type DataItem = {
+      name: string;
+    };
+
+    const columns: DataGridColumns<DataItem>[] = [
+      {
+        field: 'name',
+        label: 'Наименование',
+        sortable: true,
+      },
+    ];
+
+    renderWithTheme(
+      <DataGrid
+        keyId="id"
+        rows={[{ name: 'name' }]}
+        columns={columns}
+        Footer={<span>Footer is visible</span>}
+        totalCount={1}
+        minDisplayRows={10}
+      />,
+    );
+
+    const title = screen.queryByText(/Footer is visible/i);
+
+    expect(title).not.toBeInTheDocument();
+  });
+
+  it('Props:totalCount=10:minDisplayRows=1: Footer отображается, totalCount > minDisplayRows', () => {
+    type DataItem = {
+      name: string;
+    };
+
+    const columns: DataGridColumns<DataItem>[] = [
+      {
+        field: 'name',
+        label: 'Наименование',
+        sortable: true,
+      },
+    ];
+
+    renderWithTheme(
+      <DataGrid
+        keyId="id"
+        rows={[{ name: 'name' }]}
+        columns={columns}
+        minDisplayRows={1}
+        totalCount={10}
+        Footer={<span>Footer is visible</span>}
+      />,
+    );
+
+    const title = screen.getByText('Footer is visible');
+
+    expect(title).toBeInTheDocument();
+  });
+
   it('Props:columns: отображаются названия колонок', () => {
     const columns = [
       {

--- a/packages/components/src/DataGrid/DataGrid.tsx
+++ b/packages/components/src/DataGrid/DataGrid.tsx
@@ -103,6 +103,12 @@ export type DataGridProps<
    * Высота Footer, по-умолчанию указана высота Footer из кита
    */
   footerHeight?: number;
+  /**
+   * @example <DateGrid totalCount={16} />
+   * Всего количество записей в таблице.
+   * Footer скрывается, если totalCount передан и totalCount <= minDisplayRows
+   */
+  totalCount?: number;
 };
 
 export function DataGrid<
@@ -126,10 +132,12 @@ export function DataGrid<
   emptyCellValue,
   className,
   footerHeight = 50,
+  totalCount,
 }: DataGridProps<Data, SortField>) {
   const selectable = Boolean(onSelectRow);
-  const withFooter = Boolean(Footer);
   const isTableDisabled = loading || disabled;
+  const isSinglePage = Boolean(totalCount && totalCount <= minDisplayRows);
+  const withFooter = Boolean(Footer && !isSinglePage);
 
   const TableContainer = isTableDisabled
     ? DisabledTableContainer
@@ -221,7 +229,7 @@ export function DataGrid<
         disabled={disabled}
         loading={loading}
       />
-      {Footer}
+      {withFooter && Footer}
     </DataGridContainer>
   );
 }

--- a/packages/components/src/DataGrid/DataGrid.tsx
+++ b/packages/components/src/DataGrid/DataGrid.tsx
@@ -97,18 +97,6 @@ export type DataGridProps<
    *  Используется для отображения переданного кол-ва строк при отсутствии данных
    */
   minDisplayRows?: number;
-  /**
-   * @default 50
-   * @example <DateGrid Footer={Footer} footerHeight={50} />
-   * Высота Footer, по-умолчанию указана высота Footer из кита
-   */
-  footerHeight?: number;
-  /**
-   * @example <DateGrid totalCount={16} />
-   * Всего количество записей в таблице.
-   * Footer скрывается, если totalCount передан и totalCount <= minDisplayRows
-   */
-  totalCount?: number;
 };
 
 export function DataGrid<
@@ -131,13 +119,9 @@ export function DataGrid<
   keyId,
   emptyCellValue,
   className,
-  footerHeight = 50,
-  totalCount,
 }: DataGridProps<Data, SortField>) {
   const selectable = Boolean(onSelectRow);
   const isTableDisabled = loading || disabled;
-  const isSinglePage = Boolean(totalCount && totalCount <= minDisplayRows);
-  const withFooter = Boolean(Footer && !isSinglePage);
 
   const TableContainer = isTableDisabled
     ? DisabledTableContainer
@@ -223,13 +207,8 @@ export function DataGrid<
           />
         </Table>
       </TableContainer>
-      <DataGridLoader
-        footerHeight={footerHeight}
-        withFooter={withFooter}
-        disabled={disabled}
-        loading={loading}
-      />
-      {withFooter && Footer}
+      <DataGridLoader disabled={disabled} loading={loading} />
+      {Footer}
     </DataGridContainer>
   );
 }

--- a/packages/components/src/DataGrid/DataGridLoader/DataGridLoader.tsx
+++ b/packages/components/src/DataGrid/DataGridLoader/DataGridLoader.tsx
@@ -8,21 +8,15 @@ import {
 export type DataGridLoaderProps = {
   loading?: boolean;
   disabled?: boolean;
-  withFooter: boolean;
-  footerHeight: number;
 };
 
 const DataGridLoader = ({
   loading = false,
   disabled = false,
-  withFooter,
-  footerHeight,
 }: DataGridLoaderProps) => {
   return (
     <LoaderWrapper>
-      {(loading || disabled) && (
-        <Backdrop withFooter={withFooter} footerHeight={footerHeight} />
-      )}
+      {(loading || disabled) && <Backdrop />}
       {loading && <StyledLinearProgress />}
       {!loading && <StyledDivider />}
     </LoaderWrapper>

--- a/packages/components/src/DataGrid/DataGridLoader/styles.ts
+++ b/packages/components/src/DataGrid/DataGridLoader/styles.ts
@@ -3,20 +3,12 @@ import { LinearProgress } from '@mui/material';
 import { Divider } from '../../Divider';
 import { styled } from '../../styles';
 
-type BackdropProps = {
-  withFooter: boolean;
-  footerHeight: number;
-};
-
-export const Backdrop = styled.div<BackdropProps>`
+export const Backdrop = styled.div`
   position: absolute;
   top: 0;
 
   width: 100%;
-
-  /* Если в DataGrid передан Footer, нужно чтобы Backdrop не перекрывал его в состоянии loading, поэтому тут его высота вычитается из всей высоты бэкдропа */
-  height: ${({ withFooter, footerHeight }) =>
-    withFooter ? `calc(100% - ${footerHeight}px) ` : '100%'};
+  height: 100%;
 
   background-color: ${({ theme }) => theme.palette.background.element};
   opacity: 0.3;

--- a/packages/components/src/DataGridPagination/DataGridPagination.test.tsx
+++ b/packages/components/src/DataGridPagination/DataGridPagination.test.tsx
@@ -7,13 +7,11 @@ const TEST_DATA = [
   { page: 3, totalCount: 24, expected: '21 — 24 из 24 записей' },
   { page: 2, totalCount: 20, expected: '11 — 20 из 20 записей' },
   { page: 2, totalCount: 19, expected: '11 — 19 из 19 записей' },
-  { page: 1, totalCount: 10, expected: '1 — 10 из 10 записей' },
-  { page: 1, totalCount: 5, expected: '1 — 5 из 5 записей' },
 ];
 
 describe('DataGridPagination', () => {
   test.each(TEST_DATA)(
-    'Props:page=$page:totalCount=$totalCount: Текст пагинации "$expected"',
+    'Props:page=$page:totalCount=$totalCount: текст пагинации "$expected"',
     ({ totalCount, page, expected }) => {
       renderWithTheme(
         <DataGridPagination totalCount={totalCount} page={page} />,
@@ -24,4 +22,12 @@ describe('DataGridPagination', () => {
       expect(text).toBeInTheDocument();
     },
   );
+
+  it('Props:totalCount=11:rowsPerPage=10: пагинация не отображается', () => {
+    const { container } = renderWithTheme(
+      <DataGridPagination page={1} totalCount={1} rowsPerPage={10} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/packages/components/src/DataGridPagination/DataGridPagination.tsx
+++ b/packages/components/src/DataGridPagination/DataGridPagination.tsx
@@ -50,6 +50,10 @@ export const DataGridPagination = ({
   }, [page, rowsPerPage, totalCount]);
   const formattedRange = `${rangeStart} — ${rangeEnd} из ${totalCount} записей`;
 
+  if (totalCount <= rowsPerPage) {
+    return null;
+  }
+
   return (
     <PaginationWrapper className={className}>
       <Range variant="h6">{formattedRange}</Range>


### PR DESCRIPTION
@Astral-design Сейчас, если пагинация в таблице не отображается, внизу таблицы показывается полоска. Норм или как-то изменить?
![image](https://user-images.githubusercontent.com/93906455/219309790-e52302ec-8c50-498a-9df6-3a28e0b77c76.png)
