### PR TITLE
bug(UIKIT-682,FormTextField): Не пробрасывается ref

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { fireEvent, renderWithTheme, screen, userEvents } from '@astral/tests';
 
 import { Autocomplete } from './Autocomplete';
@@ -172,5 +173,22 @@ describe('Autocomplete', () => {
     const tag = screen.queryByRole('button', { name: 'Pupkin' });
 
     expect(tag).toBeNull();
+  });
+
+  it('Prop:ref: is present', () => {
+    const resultRef = { current: null };
+
+    const AutocompleteWithRef = () => {
+      const ref = useRef(null);
+
+      useEffect(() => {
+        resultRef.current = ref.current;
+      }, []);
+
+      return <Autocomplete options={[]} ref={ref} />;
+    };
+
+    renderWithTheme(<AutocompleteWithRef />);
+    expect(resultRef?.current).not.toBeNull();
   });
 });

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -6,7 +6,8 @@ import {
   Autocomplete as MuiAutocomplete,
   AutocompleteProps as MuiAutocompleteProps,
 } from '@mui/material';
-import { HTMLAttributes, useCallback } from 'react';
+import { forwardRef, useCallback } from 'react';
+import type { ForwardedRef, HTMLAttributes } from 'react';
 import { ChevronDOutlineMd, CrossSmOutlineSm } from '@astral/icons';
 
 import { TextField, TextFieldProps } from '../TextField';
@@ -42,13 +43,13 @@ export type AutocompleteProps<
 > &
   Pick<
     TextFieldProps,
-    'error' | 'success' | 'helperText' | 'label' | 'required'
+    'error' | 'success' | 'helperText' | 'label' | 'required' | 'inputRef'
   > & {
     size?: AutocompleteSize;
     overflowOption?: OverflowedElementProps;
   };
 
-export const Autocomplete = <
+const AutocompleteInner = <
   AutocompleteValueProps,
   Multiple extends boolean,
   DisableClearable extends boolean,
@@ -60,6 +61,7 @@ export const Autocomplete = <
     DisableClearable,
     FreeSolo
   >,
+  ref?: ForwardedRef<unknown>,
 ) => {
   const {
     multiple,
@@ -78,6 +80,7 @@ export const Autocomplete = <
     clearText = 'Очистить',
     size = 'medium',
     overflowOption,
+    inputRef,
     ...restProps
   } = props;
 
@@ -117,6 +120,7 @@ export const Autocomplete = <
     (inputParams: AutocompleteRenderInputParams) => (
       <TextField
         {...inputParams}
+        inputRef={inputRef}
         required={required}
         placeholder={placeholder}
         label={label}
@@ -126,7 +130,7 @@ export const Autocomplete = <
         size={size}
       />
     ),
-    [placeholder, label, success, error, helperText, size, required],
+    [placeholder, label, success, error, helperText, size, required, inputRef],
   );
 
   const renderOption = useCallback(
@@ -178,6 +182,21 @@ export const Autocomplete = <
       closeText={closeText}
       openText={openText}
       clearText={clearText}
+      ref={ref}
     />
   );
 };
+
+export const Autocomplete = forwardRef(AutocompleteInner) as <
+  AutocompleteValueProps,
+  Multiple extends boolean,
+  DisableClearable extends boolean,
+  FreeSolo extends boolean,
+>(
+  props: AutocompleteProps<
+    AutocompleteValueProps,
+    Multiple,
+    DisableClearable,
+    FreeSolo
+  > & { ref?: ForwardedRef<unknown> },
+) => ReturnType<typeof AutocompleteInner>;

--- a/packages/form/src/FormAutocomplete/FormAutocomplete.test.tsx
+++ b/packages/form/src/FormAutocomplete/FormAutocomplete.test.tsx
@@ -100,10 +100,8 @@ describe('FormAutocomplete', () => {
     renderWithTheme(<TestComponent />);
     await userEvents.click(screen.getByText('submit'));
 
-    await waitFor(() => {
-      const input = screen.getByRole('combobox', { name: /user/i });
+    const input = await screen.findByRole('combobox', { name: /user/i });
 
-      expect(input).toHaveFocus();
-    });
+    expect(input).toHaveFocus();
   });
 });

--- a/packages/form/src/FormAutocomplete/FormAutocomplete.test.tsx
+++ b/packages/form/src/FormAutocomplete/FormAutocomplete.test.tsx
@@ -79,4 +79,31 @@ describe('FormAutocomplete', () => {
       });
     });
   });
+
+  it('Prop:inputRef: Фокус на поле после клика на Submit', async () => {
+    const TestComponent = () => {
+      const form = useForm();
+
+      return (
+        <Form form={form} onSubmit={form.handleSubmit(() => undefined)}>
+          <FormAutocomplete
+            name="user"
+            label="user"
+            rules={{ required: 'required' }}
+            options={[]}
+          />
+          <button type="submit">submit</button>
+        </Form>
+      );
+    };
+
+    renderWithTheme(<TestComponent />);
+    await userEvents.click(screen.getByText('submit'));
+
+    await waitFor(() => {
+      const input = screen.getByRole('combobox', { name: /user/i });
+
+      expect(input).toHaveFocus();
+    });
+  });
 });

--- a/packages/form/src/FormDatePicker/FormDatePicker.test.tsx
+++ b/packages/form/src/FormDatePicker/FormDatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithTheme, screen, userEvents } from '@astral/tests';
+import { renderWithTheme, screen, userEvents, waitFor } from '@astral/tests';
 import { vi } from 'vitest';
 
 import { Form } from '../Form';
@@ -62,5 +62,31 @@ describe('FormDatePicker', () => {
     const [submitValues] = onSubmit.mock.calls[0];
 
     expect(submitValues.date.toISOString().includes('2022-02-09')).toBeTruthy();
+  });
+
+  it('Prop:inputRef: Фокус на поле после клика на Submit', async () => {
+    const TestComponent = () => {
+      const form = useForm();
+
+      return (
+        <Form form={form} onSubmit={form.handleSubmit(() => undefined)}>
+          <FormDatePicker
+            name="date"
+            inputProps={{ label: 'date', required: true }}
+            rules={{ required: 'required' }}
+          />
+          <button type="submit">submit</button>
+        </Form>
+      );
+    };
+
+    renderWithTheme(<TestComponent />);
+    await userEvents.click(screen.getByText('submit'));
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox', { name: /date/i });
+
+      expect(input).toHaveFocus();
+    });
   });
 });

--- a/packages/form/src/FormDatePicker/FormDatePicker.test.tsx
+++ b/packages/form/src/FormDatePicker/FormDatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithTheme, screen, userEvents, waitFor } from '@astral/tests';
+import { renderWithTheme, screen, userEvents } from '@astral/tests';
 import { vi } from 'vitest';
 
 import { Form } from '../Form';
@@ -83,10 +83,8 @@ describe('FormDatePicker', () => {
     renderWithTheme(<TestComponent />);
     await userEvents.click(screen.getByText('submit'));
 
-    await waitFor(() => {
-      const input = screen.getByRole('textbox', { name: /date/i });
+    const input = await screen.findByRole('textbox', { name: /date/i });
 
-      expect(input).toHaveFocus();
-    });
+    expect(input).toHaveFocus();
   });
 });

--- a/packages/form/src/FormTextField/FormTextField.test.tsx
+++ b/packages/form/src/FormTextField/FormTextField.test.tsx
@@ -70,10 +70,8 @@ describe('FormTextField', () => {
     renderWithTheme(<TestComponent />);
     await userEvents.click(screen.getByText('submit'));
 
-    await waitFor(() => {
-      const input = screen.getByRole('textbox', { name: /user/i });
+    const input = await screen.findByRole('textbox', { name: /user/i });
 
-      expect(input).toHaveFocus();
-    });
+    expect(input).toHaveFocus();
   });
 });

--- a/packages/form/src/FormTextField/FormTextField.test.tsx
+++ b/packages/form/src/FormTextField/FormTextField.test.tsx
@@ -50,4 +50,30 @@ describe('FormTextField', () => {
     renderWithTheme(<FormTextFieldWithRef />);
     expect(resultRef?.current).not.toBeNull();
   });
+
+  it('Prop:ref: Фокус на поле после клика на Submit', async () => {
+    const TestComponent = () => {
+      const form = useForm();
+
+      return (
+        <Form form={form} onSubmit={form.handleSubmit(() => undefined)}>
+          <FormTextField
+            name="user"
+            label="user"
+            rules={{ required: 'required' }}
+          />
+          <button type="submit">submit</button>
+        </Form>
+      );
+    };
+
+    renderWithTheme(<TestComponent />);
+    await userEvents.click(screen.getByText('submit'));
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox', { name: /user/i });
+
+      expect(input).toHaveFocus();
+    });
+  });
 });

--- a/packages/form/src/FormTextField/FormTextField.test.tsx
+++ b/packages/form/src/FormTextField/FormTextField.test.tsx
@@ -51,7 +51,7 @@ describe('FormTextField', () => {
     expect(resultRef?.current).not.toBeNull();
   });
 
-  it('Prop:ref: Фокус на поле после клика на Submit', async () => {
+  it('Prop:inputRef: Фокус на поле после клика на Submit', async () => {
     const TestComponent = () => {
       const form = useForm();
 

--- a/packages/form/src/hooks/useFormFieldProps/useFormFieldProps.ts
+++ b/packages/form/src/hooks/useFormFieldProps/useFormFieldProps.ts
@@ -30,5 +30,5 @@ export const useFormFieldProps = <
 
   const errorProps = useFormFieldErrorProps(fieldState);
 
-  return { ...inputProps, ...field, ...errorProps, ref };
+  return { ...inputProps, ...field, ...errorProps, inputProps: { ref } };
 };

--- a/packages/form/src/hooks/useFormFieldProps/useFormFieldProps.ts
+++ b/packages/form/src/hooks/useFormFieldProps/useFormFieldProps.ts
@@ -30,5 +30,5 @@ export const useFormFieldProps = <
 
   const errorProps = useFormFieldErrorProps(fieldState);
 
-  return { ...inputProps, ...field, ...errorProps, inputProps: { ref } };
+  return { ...inputProps, ...field, ...errorProps, inputRef: ref };
 };


### PR DESCRIPTION
- исправлен inputProps.ref
В компонентах Autocomplete, DatePicker inputProps.ref пробрасывался корректно