### PR TITLE
feat(UIKIT-632, ThemeProvider): Добавлен пропс withoutGlobalStyles

### DIFF
--- a/packages/components/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/components/src/GlobalStyles/GlobalStyles.tsx
@@ -1,15 +1,26 @@
 import { Global } from '@emotion/react';
-import { CssBaseline } from '@mui/material';
-import { CssBaselineProps as GlobalStylesProps } from '@mui/material/CssBaseline';
+import { CssBaseline, ScopedCssBaseline } from '@mui/material';
+import { CssBaselineProps } from '@mui/material/CssBaseline';
 
 import { Theme, useTheme } from '../theme';
 
-export const GlobalStyles = ({ children, ...props }: GlobalStylesProps) => {
+type GlobalStylesProps = CssBaselineProps & {
+  withoutGlobalStyles?: boolean;
+};
+
+export const GlobalStyles = ({
+  children,
+  withoutGlobalStyles = false,
+  ...props
+}: GlobalStylesProps) => {
   const theme: Theme = useTheme();
 
   return (
     <>
-      <CssBaseline {...props}>{children}</CssBaseline>
+      {!withoutGlobalStyles && <CssBaseline {...props}>{children}</CssBaseline>}
+      {withoutGlobalStyles && (
+        <ScopedCssBaseline {...props}>{children}</ScopedCssBaseline>
+      )}
       <Global
         styles={{
           html: {

--- a/packages/components/src/ThemeProvider/ThemeProvider.tsx
+++ b/packages/components/src/ThemeProvider/ThemeProvider.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, ReactNode } from 'react';
+import { ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
 
@@ -6,18 +7,20 @@ import { GlobalStyles } from '../GlobalStyles';
 import { Theme } from '../theme';
 
 export type ThemeProviderProps = {
-  theme: Theme;
   children: ReactNode;
+  theme: Theme;
+  withoutGlobalStyles?: boolean;
 };
 
 export const ThemeProvider = (props: PropsWithChildren<ThemeProviderProps>) => {
-  const { theme, children } = props;
+  const { children, theme, withoutGlobalStyles = false } = props;
 
   return (
     <MuiThemeProvider theme={theme}>
       <EmotionThemeProvider theme={theme}>
-        <GlobalStyles />
-        {children}
+        <GlobalStyles withoutGlobalStyles={withoutGlobalStyles}>
+          {children}
+        </GlobalStyles>
       </EmotionThemeProvider>
     </MuiThemeProvider>
   );

--- a/packages/components/src/theme/components/components.ts
+++ b/packages/components/src/theme/components/components.ts
@@ -54,39 +54,49 @@ export type FontsUrls = {
   };
 };
 
+const getFontFaces = (fontUrls: FontsUrls): string => `
+  @font-face {
+    font-family: 'Ubuntu';
+    font-style: 'normal';
+    font-weight: 300;
+    font-display: swap;
+    src: url(${fontUrls.light.woff2}) format('woff2'), url(${fontUrls.light.woff}) format('woff');
+  }
+  @font-face { 
+    font-family: 'Ubuntu';
+    font-style: 'normal';
+    font-weight: 400;
+    font-display: swap;
+    src: url(${fontUrls.regular.woff2}) format('woff2'), url(${fontUrls.regular.woff}) format('woff');
+  }
+  @font-face {
+    font-family: 'Ubuntu';
+    font-style: 'normal';
+    font-weight: 500;
+    font-display: swap;
+    src: url(${fontUrls.medium.woff2}) format('woff2'), url(${fontUrls.medium.woff}) format('woff');
+  }
+  @font-face {
+    font-family: 'Ubuntu';
+    font-style: 'normal';
+    font-weight: 700;
+    font-display: swap;
+    src: url(${fontUrls.bold.woff2}) format('woff2'), url(${fontUrls.bold.woff}) format('woff');
+  }
+`;
+
 const getMuiCssBaseline = (
   fontUrls: FontsUrls,
 ): Components['MuiCssBaseline'] => ({
-  styleOverrides: `
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: 'normal';
-      font-weight: 300;
-      font-display: swap;
-      src: url(${fontUrls.light.woff2}) format('woff2'), url(${fontUrls.light.woff}) format('woff');
-    }
-    @font-face { 
-      font-family: 'Ubuntu';
-      font-style: 'normal';
-      font-weight: 400;
-      font-display: swap;
-      src: url(${fontUrls.regular.woff2}) format('woff2'), url(${fontUrls.regular.woff}) format('woff');
-    }
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: 'normal';
-      font-weight: 500;
-      font-display: swap;
-      src: url(${fontUrls.medium.woff2}) format('woff2'), url(${fontUrls.medium.woff}) format('woff');
-    }
-    @font-face {
-      font-family: 'Ubuntu';
-      font-style: 'normal';
-      font-weight: 700;
-      font-display: swap;
-      src: url(${fontUrls.bold.woff2}) format('woff2'), url(${fontUrls.bold.woff}) format('woff');
-    }
-  `,
+  styleOverrides: getFontFaces(fontUrls),
+});
+
+const getMuiScopedCssBaseline = (
+  fontUrls: FontsUrls,
+): Components['MuiScopedCssBaseline'] => ({
+  styleOverrides: {
+    root: getFontFaces(fontUrls),
+  },
 });
 
 const MuiCheckbox: Components['MuiCheckbox'] = {
@@ -103,6 +113,7 @@ const MuiRadio: Components['MuiRadio'] = {
 
 export const getComponents = (fontUrls: FontsUrls): Components<Theme> => ({
   MuiCssBaseline: getMuiCssBaseline(fontUrls),
+  MuiScopedCssBaseline: getMuiScopedCssBaseline(fontUrls),
   MuiAlert,
   MuiButton,
   MuiButtonBase,


### PR DESCRIPTION
добавлен компонент `ScopedCssBaseline`, который позволяет задать стили только для блока (который обёрнут в ThemeProvider)
- когда блок обёрнут в ScopedCssBaseline, то для body НЕ задаётся font-family