### PR TITLE
feat(UIKIT-758,ui,DataGrid): Ячейки приведены к единой начальной высоте 44px

### DIFF
--- a/packages/components/src/DataGrid/DataGrid.stories.tsx
+++ b/packages/components/src/DataGrid/DataGrid.stories.tsx
@@ -71,7 +71,13 @@ const columns: DataGridColumns<DataType>[] = [
     sortable: false,
     align: 'center',
     width: '1%',
-    renderCell: (row) => <ActionCell actions={ACTIONS} row={row} />,
+    renderCell: (row) => {
+      if (['1', '2', '3', '4'].includes(row.id)) {
+        return null;
+      }
+
+      return <ActionCell actions={ACTIONS} row={row} />;
+    },
   },
 ];
 

--- a/packages/components/src/theme/components/MuiTableCell.ts
+++ b/packages/components/src/theme/components/MuiTableCell.ts
@@ -4,9 +4,11 @@ import type { Theme } from '../baseTheme';
 
 export const MuiTableCell: Components<Theme>['MuiTableCell'] = {
   styleOverrides: {
-    root() {
+    root({ theme }) {
       return {
         border: 'none',
+        padding: theme.spacing(1, 4),
+        height: 44,
       };
     },
   },

--- a/packages/components/src/theme/components/MuiTableCell.ts
+++ b/packages/components/src/theme/components/MuiTableCell.ts
@@ -8,7 +8,7 @@ export const MuiTableCell: Components<Theme>['MuiTableCell'] = {
       return {
         border: 'none',
         padding: theme.spacing(1, 4),
-        // 44px - высота, установленная в дизайн-системе
+        // 44px - минимальная высота ячейки, установленная в дизайн-системе
         height: 44,
       };
     },

--- a/packages/components/src/theme/components/MuiTableCell.ts
+++ b/packages/components/src/theme/components/MuiTableCell.ts
@@ -8,6 +8,7 @@ export const MuiTableCell: Components<Theme>['MuiTableCell'] = {
       return {
         border: 'none',
         padding: theme.spacing(1, 4),
+        // 44px - высота, установленная в дизайн-системе
         height: 44,
       };
     },


### PR DESCRIPTION
Сейчас, если у строки нет действий (ActionCell), она имеет меньшую высоту, чем строка с действиями. В табличке, где есть оба типа таких строк это смотрится коряво