### PR TITLE
bug(UIKIT-1028,Components): Обновление версии для emotion/cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2988,18 +2988,6 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
-    "node_modules/@emotion/cache": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
-      "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
-      "dependencies": {
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.1.0",
-        "@emotion/utils": "^1.0.0",
-        "@emotion/weak-memoize": "^0.2.5",
-        "stylis": "4.0.13"
-      }
-    },
     "node_modules/@emotion/hash": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
@@ -3017,11 +3005,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
-      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
     },
     "node_modules/@emotion/react": {
       "version": "11.11.1",
@@ -3153,11 +3136,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
       "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.17",
@@ -26343,7 +26321,7 @@
       "version": "3.0.0",
       "dependencies": {
         "@astral/icons": "*",
-        "@emotion/cache": "11.7.1",
+        "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.10.6",
         "@emotion/server": "^11.10.0",
         "@emotion/styled": "^11.10.6",
@@ -26363,6 +26341,33 @@
       "peerDependencies": {
         "react": ">=17.0.0"
       }
+    },
+    "packages/components/node_modules/@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "packages/components/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "packages/components/node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+    },
+    "packages/components/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "packages/features": {
       "name": "@astral/features",
@@ -26482,7 +26487,7 @@
       "requires": {
         "@astral/icons": "*",
         "@astral/tests": "*",
-        "@emotion/cache": "11.7.1",
+        "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.10.6",
         "@emotion/server": "^11.10.0",
         "@emotion/styled": "^11.10.6",
@@ -26495,6 +26500,35 @@
         "react-imask": "6.4.2",
         "react-toastify": "9.0.3",
         "react-use": "^17.4.0"
+      },
+      "dependencies": {
+        "@emotion/cache": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+          "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+          "requires": {
+            "@emotion/memoize": "^0.8.1",
+            "@emotion/sheet": "^1.2.2",
+            "@emotion/utils": "^1.2.1",
+            "@emotion/weak-memoize": "^0.3.1",
+            "stylis": "4.2.0"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+          "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+        },
+        "@emotion/weak-memoize": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+          "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+        },
+        "stylis": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+          "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+        }
       }
     },
     "@astral/cryptopro-cades": {
@@ -28546,18 +28580,6 @@
         }
       }
     },
-    "@emotion/cache": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
-      "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
-      "requires": {
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.1.0",
-        "@emotion/utils": "^1.0.0",
-        "@emotion/weak-memoize": "^0.2.5",
-        "stylis": "4.0.13"
-      }
-    },
     "@emotion/hash": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
@@ -28577,11 +28599,6 @@
           "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
         }
       }
-    },
-    "@emotion/memoize": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
-      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
     },
     "@emotion/react": {
       "version": "11.11.1",
@@ -28690,11 +28707,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
       "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
-    },
-    "@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@esbuild/android-arm": {
       "version": "0.18.17",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@astral/icons": "*",
-    "@emotion/cache": "11.7.1",
+    "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.10.6",
     "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.10.6",


### PR DESCRIPTION
package.json имеет зависимость `"@emotion/cache": "11.7.1"` и используемый `"@mui/material"` так же использует `@emotion/cache`, но немного другой версии. И т.к. у нас версия указана конкретная, без "крышки", мы получаем эффект двух одинаковых плагинов.

решение: использовать схожую версию emotion/cache, и добавить к ней "крышку"

# Чеклист

- [ ] Написать тесты для реализованного функционала
- [ ] Описать jsdoc для экспортируемых функций, компонентов
- [ ] Описать jsdoc для props экспортируемых компонентов
- [ ] Реализовать или обновить storybook для компонента
- [ ] Проверить код на соответствие [style guide](https://track.astral.ru/soft/wiki/display/FG/Style+guide)
- [ ] Запросить ревью у дизайнера, если был изменен ui или создан новый компонент
