### PR TITLE
bug(UIKIT-1368,ui,CodeField): Центрирован инпут числа

### DIFF
--- a/packages/components/src/CodeField/styles.ts
+++ b/packages/components/src/CodeField/styles.ts
@@ -29,6 +29,7 @@ export const Digit = styled.input<{ isError?: boolean }>`
   color: ${({ theme, isError }) => {
     return isError ? theme.palette.error.dark : theme.palette.grey[900];
   }};
+  text-align: center;
 
   background: ${({ theme }) => theme.palette.background.elementHover};
   border: unset;


### PR DESCRIPTION
Маленький фикс, теперь курсор инпута числа будет отображаться ровно по середине.