### PR TITLE
bug(UIKIT-1389,ui,Notification): Добавлен перенос текста при переполнении

### DIFF
--- a/packages/components/src/Notification/NotificationTemplate/styles.ts
+++ b/packages/components/src/Notification/NotificationTemplate/styles.ts
@@ -36,6 +36,8 @@ export const Wrapper = styled.article<NotificationTemplateProps>`
 
 export const Inner = styled.div`
   flex-grow: 1;
+
+  overflow-wrap: anywhere;
 `;
 
 export const Footer = styled.footer<NotificationActionsProps>`
@@ -72,6 +74,8 @@ export const CloseIcon = styled(CrossOutlineSm, {
 export const CloseButton = styled(IconButton, {
   shouldForwardProp: (prop) => prop !== 'filled',
 })<NotificationCloseButtonProps>`
+  align-self: flex-start;
+
   padding: 0;
 
   &:hover {


### PR DESCRIPTION
Был добавлен перенос текста, если тестовое содержимое уведомления переполняют контейнер, также пофикшена кнопка, которая при title больше 2 строк начала криво отображаться

# Чеклист

- [x] Написать тесты для реализованного функционала
- [x] Описать jsdoc для экспортируемых функций, компонентов
- [x] Описать jsdoc для props экспортируемых компонентов
- [x] Реализовать или обновить storybook для компонента
- [x] Проверить код на соответствие [style guide](https://track.astral.ru/soft/wiki/display/FG/Style+guide)
- [x] Запросить ревью у дизайнера, если был изменен ui или создан новый компонент
