### PR TITLE
feat(UIKIT-1634,NavMenu): Добавлена возможность передавать ReactNode в item.text

### DIFF
--- a/packages/components/src/DashboardLayout/Sidebar/Sidebar.stories.tsx
+++ b/packages/components/src/DashboardLayout/Sidebar/Sidebar.stories.tsx
@@ -8,6 +8,7 @@ import { type MouseEvent, type ReactElement, forwardRef } from 'react';
 
 import { styled } from '../../styles/styled';
 import { DashboardLayout } from '../DashboardLayout';
+import { OverflowTypography } from '../../OverflowTypography';
 
 import { SidebarButton } from './SidebarButton';
 
@@ -188,7 +189,7 @@ export const Interaction: Story = {
   },
 };
 
-export const Menu = () => {
+export const Example = () => {
   return (
     <DashboardLayoutWrapper>
       <DashboardLayout>
@@ -496,6 +497,80 @@ export const SidebarButtonInHeader = () => {
                       <RouterLink ref={ref} to="/organizations" {...props} />
                     );
                   }),
+                },
+              ],
+            ],
+          }}
+        />
+      </DashboardLayout>
+    </DashboardLayoutWrapper>
+  );
+};
+
+/**
+ * text prop - ReactNode, поэтому в него можно передать любой кастомный компонент, например OverflowTypography
+ */
+export const CustomItemText = () => {
+  return (
+    <DashboardLayoutWrapper>
+      <DashboardLayout>
+        <DashboardLayout.Header
+          product={{
+            name: 'Астрал',
+            logo() {
+              return <Logo />;
+            },
+          }}
+        />
+        <DashboardLayout.Sidebar
+          menu={{
+            items: [
+              [
+                'documents',
+                {
+                  icon: <ProfileOutlineMd />,
+                  text: (
+                    <OverflowTypography
+                      tooltipProps={{ placement: 'right' }}
+                      style={{ width: 170 }}
+                    >
+                      Документы Иванова Ивана Васильевича
+                    </OverflowTypography>
+                  ),
+                  items: [
+                    [
+                      'incoming-documents',
+                      {
+                        text: 'Входящие документы',
+                        active: true,
+                        component: forwardRef((props, ref) => {
+                          return (
+                            <RouterLink
+                              ref={ref}
+                              to="/incoming-documents"
+                              {...props}
+                            />
+                          );
+                        }),
+                      },
+                    ],
+                    [
+                      'outgoing-documents',
+                      {
+                        text: 'Исходящие документы',
+                        active: false,
+                        component: forwardRef((props, ref) => {
+                          return (
+                            <RouterLink
+                              ref={ref}
+                              to="/outgoing-documents"
+                              {...props}
+                            />
+                          );
+                        }),
+                      },
+                    ],
+                  ],
                 },
               ],
             ],

--- a/packages/components/src/DashboardLayout/Sidebar/Sidebar.stories.tsx
+++ b/packages/components/src/DashboardLayout/Sidebar/Sidebar.stories.tsx
@@ -6,7 +6,7 @@ import {
 import { type Meta, type StoryObj } from '@storybook/react';
 import { type MouseEvent, type ReactElement, forwardRef } from 'react';
 
-import { styled } from '../../styles/styled';
+import { styled } from '../../styles';
 import { DashboardLayout } from '../DashboardLayout';
 import { OverflowTypography } from '../../OverflowTypography';
 
@@ -511,6 +511,10 @@ export const SidebarButtonInHeader = () => {
  * text prop - ReactNode, поэтому в него можно передать любой кастомный компонент, например OverflowTypography
  */
 export const CustomItemText = () => {
+  const CustomNavItemText = styled(OverflowTypography)`
+    width: 170px;
+  `;
+
   return (
     <DashboardLayoutWrapper>
       <DashboardLayout>
@@ -530,12 +534,9 @@ export const CustomItemText = () => {
                 {
                   icon: <ProfileOutlineMd />,
                   text: (
-                    <OverflowTypography
-                      tooltipProps={{ placement: 'right' }}
-                      style={{ width: 170 }}
-                    >
+                    <CustomNavItemText tooltipProps={{ placement: 'right' }}>
                       Документы Иванова Ивана Васильевича
-                    </OverflowTypography>
+                    </CustomNavItemText>
                   ),
                   items: [
                     [

--- a/packages/components/src/NavMenu/Item/Item.tsx
+++ b/packages/components/src/NavMenu/Item/Item.tsx
@@ -1,6 +1,7 @@
 import {
   type ElementType,
   type ReactElement,
+  type ReactNode,
   useCallback,
   useMemo,
   useState,
@@ -17,7 +18,7 @@ export type ItemProps = {
     key: string,
     value: {
       icon: ReactElement;
-      text: string;
+      text: ReactNode;
       active?: boolean;
       component?: ElementType;
       items?: ListProps['items'];

--- a/packages/components/src/NavMenu/Item/ItemButton/ItemButton.tsx
+++ b/packages/components/src/NavMenu/Item/ItemButton/ItemButton.tsx
@@ -1,4 +1,9 @@
-import { type ElementType, type ReactElement, forwardRef } from 'react';
+import {
+  type ElementType,
+  type ReactElement,
+  type ReactNode,
+  forwardRef,
+} from 'react';
 
 import { useViewportType } from '../../../hooks/useViewportType';
 import { type ListItemTextProps } from '../../../ListItemText';
@@ -16,7 +21,7 @@ export type NavMenuItemButtonProps = {
   opened?: boolean;
   collapsedIn: boolean;
   selected?: boolean;
-  text: string;
+  text: ReactNode;
   icon: ReactElement;
   component?: ElementType;
   onClick?: () => void;

--- a/packages/components/src/NavMenu/Item/List/List.tsx
+++ b/packages/components/src/NavMenu/Item/List/List.tsx
@@ -1,4 +1,4 @@
-import { type ElementType } from 'react';
+import { type ElementType, type ReactNode } from 'react';
 import { List as MuiList } from '@mui/material';
 import { PageDotOutlineMd } from '@astral/icons';
 
@@ -10,7 +10,7 @@ export type ListProps = {
     [
       key: string,
       value: {
-        text: string;
+        text: ReactNode;
         active: boolean;
         component: ElementType;
       },

--- a/packages/components/src/NavMenu/NavMenu.stories.tsx
+++ b/packages/components/src/NavMenu/NavMenu.stories.tsx
@@ -11,7 +11,6 @@ import { NavMenu } from './NavMenu';
  * ### [Figma]()
  * ### [Guide]()
  */
-
 const meta: Meta<typeof NavMenu> = {
   title: 'Components/NavMenu',
   component: NavMenu,

--- a/packages/components/src/NavMenu/NavMenu.stories.tsx
+++ b/packages/components/src/NavMenu/NavMenu.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { CompanyOutlineMd, ProfileOutlineMd } from '@astral/icons';
 
 import { OverflowTypography } from '../OverflowTypography';
+import { styled } from '../styles';
 
 import { NavMenu } from './NavMenu';
 
@@ -89,6 +90,10 @@ export const Example = () => {
  * text props - ReactNode, поэтому вместо string можно передать любой компонент
  */
 export const OverflowText = () => {
+  const StyledOverflowTypography = styled(OverflowTypography)`
+    width: 150px;
+  `;
+
   return (
     <NavMenu
       items={[
@@ -97,12 +102,9 @@ export const OverflowText = () => {
           {
             icon: <ProfileOutlineMd />,
             text: (
-              <OverflowTypography
-                tooltipProps={{ placement: 'right' }}
-                style={{ width: '150px' }}
-              >
+              <StyledOverflowTypography tooltipProps={{ placement: 'right' }}>
                 Входящие документы Иванова Ивана Васильевича
-              </OverflowTypography>
+              </StyledOverflowTypography>
             ),
             active: true,
           },

--- a/packages/components/src/NavMenu/NavMenu.stories.tsx
+++ b/packages/components/src/NavMenu/NavMenu.stories.tsx
@@ -1,6 +1,8 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { CompanyOutlineMd, ProfileOutlineMd } from '@astral/icons';
 
+import { OverflowTypography } from '../OverflowTypography';
+
 import { NavMenu } from './NavMenu';
 
 /**
@@ -68,6 +70,40 @@ export const Example = () => {
           {
             icon: <ProfileOutlineMd />,
             text: 'Входящие документы',
+            active: true,
+          },
+        ],
+        [
+          'organizations',
+          {
+            icon: <CompanyOutlineMd />,
+            text: 'Мои организации',
+          },
+        ],
+      ]}
+    />
+  );
+};
+
+/**
+ * text props - ReactNode, поэтому вместо string можно передать любой компонент
+ */
+export const OverflowText = () => {
+  return (
+    <NavMenu
+      items={[
+        [
+          'incoming-documents',
+          {
+            icon: <ProfileOutlineMd />,
+            text: (
+              <OverflowTypography
+                tooltipProps={{ placement: 'right' }}
+                style={{ width: '150px' }}
+              >
+                Входящие документы Иванова Ивана Васильевича
+              </OverflowTypography>
+            ),
             active: true,
           },
         ],

--- a/packages/components/src/OverflowTypography/OverflowTypography.tsx
+++ b/packages/components/src/OverflowTypography/OverflowTypography.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { type ReactNode, forwardRef } from 'react';
 import { type PropsWithChildren } from 'react';
 
 import { Tooltip } from '../Tooltip';
@@ -24,7 +24,13 @@ type TooltipCustomizable = {
    * @example <OverflowTypography tooltipProps={{placement: 'top-start'}} />
    * @description способ кастомизировать тултип при необходимости
    */
-  tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
+  tooltipProps?: Omit<TooltipProps, 'children' | 'title'> & {
+    /**
+     * Кастомный контент внутри tooltip. Данный props перекрывает дефолтный текст,
+     * когда строка не вмещается в контейнер
+     */
+    title?: ReactNode;
+  };
 };
 
 export type OverflowedElementProps = OverflowedProps &

--- a/packages/components/src/OverflowTypography/OverflowTypography.tsx
+++ b/packages/components/src/OverflowTypography/OverflowTypography.tsx
@@ -24,7 +24,7 @@ type TooltipCustomizable = {
    * @example <OverflowTypography tooltipProps={{placement: 'top-start'}} />
    * @description способ кастомизировать тултип при необходимости
    */
-  tooltipProps?: Omit<TooltipProps, 'children'>;
+  tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
 };
 
 export type OverflowedElementProps = OverflowedProps &


### PR DESCRIPTION
# Чеклист

- [x] Реализовать или обновить storybook для компонента
- [x] Проверить код на соответствие [style guide](https://track.astral.ru/soft/wiki/display/FG/Style+guide)

# Description

Для OverflowTypography добавлена возможность указать tooltipProps без title
